### PR TITLE
fix constructor and Properties of Model

### DIFF
--- a/src/Swagger/ApiDeclaration/Model.php
+++ b/src/Swagger/ApiDeclaration/Model.php
@@ -10,7 +10,7 @@ class Model extends Document {
     
     public function __construct($document = null, $name) {
         $this->setName($name);
-        parent::__construct($name);
+        parent::__construct($document);
     }
     
     public function getName() {

--- a/src/Swagger/Document.php
+++ b/src/Swagger/Document.php
@@ -44,6 +44,9 @@ abstract class Document {
     
     public function getSubDocuments($name, $factory, $passIndex = false) {
         $documents = $this->getDocumentProperty($name);
+        if(is_object($documents)) {
+            $documents = $this->convertStdClassToAssociativeArray($documents);
+        }
         if(is_array($documents)) {
             foreach($documents as $key => $document) {
                 if($passIndex) {
@@ -89,5 +92,17 @@ abstract class Document {
         }
         $this->document = $document;
         return $this;
+    }
+
+    /**
+     * @param $documents
+     * @return array
+     */
+    protected function convertStdClassToAssociativeArray($documents) {
+        $return = array();
+        foreach (get_object_vars($documents) as $key => $document) {
+            $return[$key] = $document;
+        }
+        return $return;
     }
 }


### PR DESCRIPTION
`properties` of a `model` is a map (not a simple list). The `getSubDocuments` method was not able to iterate over it.
