### PR TITLE
return right Api class in an ApiDeclaration

### DIFF
--- a/src/Swagger/ApiDeclaration.php
+++ b/src/Swagger/ApiDeclaration.php
@@ -4,7 +4,12 @@ namespace Swagger;
 use Swagger\ApiDeclaration\Api;
 use InvalidArgumentException;
 
-class ApiDeclaration extends ResourceListing {    
+class ApiDeclaration extends ResourceListing {
+
+    public static function apiFromDocument($document) {
+        return new Api($document);
+    }
+    
     public function getResourcePath() {
         return parent::getDocumentProperty('resourcePath');
     }


### PR DESCRIPTION
The `ApiDeclaration` returned the wrong `Api` objects (was `ResourceListing\Api`, should be `ApiDeclaration\Api`)
