### PR TITLE
Fix namespace for Model class

### DIFF
--- a/src/Swagger/ApiDeclaration.php
+++ b/src/Swagger/ApiDeclaration.php
@@ -3,6 +3,7 @@ namespace Swagger;
 
 use Swagger\ApiDeclaration\Api;
 use InvalidArgumentException;
+use Swagger\ApiDeclaration\Model;
 
 class ApiDeclaration extends ResourceListing {    
     public function getResourcePath() {

--- a/src/Swagger/ApiDeclaration/Model.php
+++ b/src/Swagger/ApiDeclaration/Model.php
@@ -1,5 +1,5 @@
 <?php
-namespace Swagger\ApiDeclaration\Model;
+namespace Swagger\ApiDeclaration;
 
 use Swagger\Document;
 use Swagger\ApiDeclaration\Model\Property;


### PR DESCRIPTION
There seems to be a mixup between the location and the namespace of the `Model` class.

This results in `PHP Fatal error:  Class 'Swagger\Model' not found in [...]/thefrozenfire/swagger/src/Swagger/ApiDeclaration.php on line 30`.

This change changes the namespace of the class to match the location.
