### PR TITLE
fix parse error

### DIFF
--- a/src/Swagger/SchemaResolver.php
+++ b/src/Swagger/SchemaResolver.php
@@ -180,7 +180,7 @@ class SchemaResolver
         $ref = $reference->getRef();
     
         if($reference->hasUri()) {
-            $uri = $reference->getUri()
+            $uri = $reference->getUri();
             if(!$this->hasRelativeResolver($uri)) {
                 throw (new SwaggerException\RelativeResolverUnavailableException)
                     ->setUri($uri);


### PR DESCRIPTION
I had this error:

```
PHP Parse error:  syntax error, unexpected 'if' (T_IF) in /home/dn/git/graviton2/vendor/thefrozenfire/swagger/src/Swagger/SchemaResolver.php on line 184
```

And indeed, there seems to be a parse error there.. PR corrects this..

Kinda wonder how this didn't come up before tagging(?)
