### PR TITLE
Allow installation with php 7 (again)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         }
     ],
     "require": {
-        "php": "^5.5"
+        "php": ">=5.5"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
This is currently possible up to v2.0.7 and was then blocked due to requiring ^5.5. So it is not possible to install the latest version for php 7 without --ignore-platform-reqs option. 