### PR TITLE
Enhancement: Validate composer.json on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ cache:
   directories:
     - $HOME/.composer/cache
 
+before_install:
+   - composer validate
+
 install:
    - composer install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,18 @@
 language: php
+
 php:
   - 5.6
   - 5.5
-before_script:
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+install:
    - composer install
-script: "phpunit --verbose --coverage-clover ./build/logs/clover.xml"
-after_script:
+
+script:
+  - vendor/bin/phpunit --verbose --coverage-clover ./build/logs/clover.xml
+
+after_success:
   - php vendor/bin/coveralls -v

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,6 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~3.7.22",
-        "satooshi/php-coveralls": "^1.0"
+        "satooshi/php-coveralls": "^0.6.1"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "thefrozenfire/swagger",
+    "license": "MIT",
     "description": "Swagger parser for PHP",
     "authors": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "215ab47952dbd4ac0220d70ce0c4fdab",
-    "content-hash": "3064c451e728ac4702fe5bc98c756cec",
+    "content-hash": "6a34ee9c84bd23a58fb52b061ea3d108",
     "packages": [],
     "packages-dev": [
         {
@@ -101,7 +100,8 @@
                 "rest",
                 "web service"
             ],
-            "time": "2015-03-18 18:23:50"
+            "abandoned": "guzzlehttp/guzzle",
+            "time": "2015-03-18T18:23:50+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -162,7 +162,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2014-09-02 10:13:14"
+            "time": "2014-09-02T10:13:14+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -209,7 +209,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-06-21 13:08:43"
+            "time": "2015-06-21T13:08:43+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -250,7 +250,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -291,7 +291,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2015-06-21 08:01:12"
+            "time": "2015-06-21T08:01:12+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -341,7 +341,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2014-03-03 05:10:30"
+            "time": "2014-03-03T05:10:30+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -414,7 +414,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2014-10-17 09:04:17"
+            "time": "2014-10-17T09:04:17+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -463,7 +463,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2013-01-13 10:24:48"
+            "time": "2013-01-13T10:24:48+00:00"
         },
         {
             "name": "psr/log",
@@ -501,7 +501,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2012-12-21 11:40:51"
+            "time": "2012-12-21T11:40:51+00:00"
         },
         {
             "name": "satooshi/php-coveralls",
@@ -569,7 +569,7 @@
                 "github",
                 "test"
             ],
-            "time": "2013-05-04 08:07:33"
+            "time": "2013-05-04T08:07:33+00:00"
         },
         {
             "name": "symfony/config",
@@ -582,7 +582,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://api.github.com/repos/symfony/config/zipball/2b1e4d626fe171ee5e8e373a872428109a5781bf",
-                "reference": "5ab9ff48b3cb5b40951a607f77fc1cbfd29edba8",
+                "reference": "2b1e4d626fe171ee5e8e373a872428109a5781bf",
                 "shasum": ""
             },
             "require": {
@@ -619,7 +619,7 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2015-08-27 06:45:45"
+            "time": "2015-08-27T06:45:45+00:00"
         },
         {
             "name": "symfony/console",
@@ -676,7 +676,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2015-09-03 11:40:38"
+            "time": "2015-09-03T11:40:38+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -734,7 +734,7 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2015-08-24 07:13:45"
+            "time": "2015-08-24T07:13:45+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -783,7 +783,7 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2015-08-27 07:03:44"
+            "time": "2015-08-27T07:03:44+00:00"
         },
         {
             "name": "symfony/stopwatch",
@@ -832,7 +832,7 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2015-08-24 07:13:45"
+            "time": "2015-08-24T07:13:45+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -881,7 +881,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2015-08-24 07:13:45"
+            "time": "2015-08-24T07:13:45+00:00"
         }
     ],
     "aliases": [],
@@ -890,7 +890,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^5.5"
+        "php": ">=5.5"
     },
     "platform-dev": []
 }


### PR DESCRIPTION
❗️ Blocked by #18.

This PR

* [x] validates `composer.json` and `composer.lock` on Travis
* [x] specifies a license
* [x] updates `composer.lock`

Follows https://github.com/TheFrozenFire/PHP-Swagger-Parser/pull/15.

💁‍♂️ Running

```
$ composer validate
```

on current `2.0` yields

```
./composer.json is valid, but with a few warnings
See https://getcomposer.org/doc/04-schema.md for details on the schema
The lock file is not up to date with the latest changes in composer.json, it is recommended that you run `composer update`.
No license specified, it is recommended to do so. For closed-source software you may use "proprietary" as license.
```

For reference, see https://getcomposer.org/doc/03-cli.md#validate. 
